### PR TITLE
chore: Bump client version 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.17
 
 require (
 	github.com/go-openapi/strfmt v0.21.7
-	github.com/itera-io/taikungoclient v0.0.0-20231101094350-b236691906eb
-	github.com/itera-io/taikungoclient/client v0.0.0-20231101094350-b236691906eb
-	github.com/itera-io/taikungoclient/showbackclient v0.0.0-20231101094350-b236691906eb
+	github.com/itera-io/taikungoclient v0.0.0-20231108163040-e87aa3bc38ff
 	github.com/jedib0t/go-pretty/v6 v6.4.9
 	github.com/spf13/cobra v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/itera-io/taikungoclient v0.0.0-20231101094350-b236691906eb h1:GrLPHrgKnUvgrvb+I2QkuZLhvCNBNVCwApxWrWUIKjc=
-github.com/itera-io/taikungoclient v0.0.0-20231101094350-b236691906eb/go.mod h1:h92Xj2Nb3q/uBTVnIK+EzBuUuTfqaq5d0tGHo/Y54ew=
-github.com/itera-io/taikungoclient/client v0.0.0-20231101094350-b236691906eb h1:9EdJiS1TnfsZvCog2Xf3d2bpTFXn92T699Ujbvhyf6w=
-github.com/itera-io/taikungoclient/client v0.0.0-20231101094350-b236691906eb/go.mod h1:y72jyDVkN8g+03DMzRMR3P14QhQywPBJDJnWjX59iBs=
-github.com/itera-io/taikungoclient/showbackclient v0.0.0-20231101094350-b236691906eb h1:jhVSYcolfB68ZCuzNnVaJeU1OTNcY2Vkx8FF3XqqjiA=
-github.com/itera-io/taikungoclient/showbackclient v0.0.0-20231101094350-b236691906eb/go.mod h1:TBYG3xPrBgX1GOxGSvWUfQIFQbOVsa3ikCv69kneyJM=
+github.com/itera-io/taikungoclient v0.0.0-20231108163040-e87aa3bc38ff h1:A90MsNumVLHJVIzb+i84oe5SkX1BOOtanOY0t/tauRo=
+github.com/itera-io/taikungoclient v0.0.0-20231108163040-e87aa3bc38ff/go.mod h1:K4VqHxtXvTlIAl7XZhStsbepdGeVGilB7rRPh2djb7s=
 github.com/jedib0t/go-pretty/v6 v6.4.9 h1:vZ6bjGg2eBSrJn365qlxGcaWu09Id+LHtrfDWlB2Usc=
 github.com/jedib0t/go-pretty/v6 v6.4.9/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=


### PR DESCRIPTION
Fixes importing multiple client go modules instead of one.