### PR TITLE
fix: Rerun tests sometimes fails with Error: invalid context xx/xx/xx…

### DIFF
--- a/cmd/backupcredential/test_spec.sh
+++ b/cmd/backupcredential/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'backupcredential /credential'
+Context 'backupcredential'
   setup(){
     cname="$(_rnd_name)"
     oid=$(taikun organization add "$(_rnd_name)" --full-name "$(_rnd_name)" -I | xargs)

--- a/cmd/cloudcredential/lock/test_spec.sh
+++ b/cmd/cloudcredential/lock/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'lock/unlock'
+Context 'cloudcredential/lock'
   setup() {
     orgname="$(_rnd_name)"
     ccname="$(_rnd_name)"

--- a/cmd/cloudcredential/proxmox/list/test_spec.sh
+++ b/cmd/cloudcredential/proxmox/list/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'cloudcredential/proxmox/story'
+Context 'cloudcredential/proxmox/list'
     # ---
     # --- The story test simulates the whole process from nothing to Proxmox project with VM and k8s server (no commit) ---
     # ---

--- a/cmd/project/autoscaler/test_spec.sh
+++ b/cmd/project/autoscaler/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'project/autoscaler/aws'
+Context 'project/autoscaler'
   setup() {
     oid=$(taikun organization add "$(_rnd_name)" -f "$(_rnd_name)" -I | xargs)
     ccid=$(taikun cloud-credential aws add "$(_rnd_name)" -a "$AWS_ACCESS_KEY_ID" -s "$AWS_SECRET_ACCESS_KEY" -r "$AWS_DEFAULT_REGION" -z 1 -o "$oid" -I | xargs)

--- a/cmd/project/disablemonitoring/test_spec.sh
+++ b/cmd/project/disablemonitoring/test_spec.sh
@@ -13,7 +13,7 @@ Context 'project/disablemonitoring'
   }
   AfterAll 'cleanup'
 
-disable_monitoring() {
+  disable_monitoring() {
       taikun project disable-monitoring "$id" -q 2>/dev/null || true
   }
 

--- a/cmd/project/info/test_spec.sh
+++ b/cmd/project/info/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'project/quota'
+Context 'project/info'
   setup() {
     oid=$(taikun organization add "$(_rnd_name)" --full-name "$(_rnd_name)" -I | xargs)
     ccid=$(taikun cloud-credential openstack add "$(_rnd_name)" -o "$oid" -d "$OS_USER_DOMAIN_NAME" -p "$OS_PASSWORD" --project "$OS_PROJECT_NAME" -r "$OS_REGION_NAME" -u "$OS_USERNAME" --public-network "$OS_INTERFACE" --url "$OS_AUTH_URL" -I)

--- a/cmd/project/lock/test_spec.sh
+++ b/cmd/project/lock/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'project/lockmanager'
+Context 'project/lock'
   setup() {
     oid=$(taikun organization add "$(_rnd_name)" --full-name "$(_rnd_name)" -I | xargs)
     ccid=$(taikun cloud-credential openstack add "$(_rnd_name)" -o "$oid" -d "$OS_USER_DOMAIN_NAME" -p "$OS_PASSWORD" --project "$OS_PROJECT_NAME" -r "$OS_REGION_NAME" -u "$OS_USERNAME" --public-network "$OS_INTERFACE" --url "$OS_AUTH_URL" -I)

--- a/cmd/project/spot/test_spec.sh
+++ b/cmd/project/spot/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'project/aws-with-spot'
+Context 'project/spot'
   setup() {
     oid=$(taikun organization add "$(_rnd_name)" -f "$(_rnd_name)" -I | xargs)
     ccid=$(taikun cloud-credential aws add "$(_rnd_name)" -a "$AWS_ACCESS_KEY_ID" -s "$AWS_SECRET_ACCESS_KEY" -r "$AWS_DEFAULT_REGION" -z 1 -o "$oid" -I | xargs)

--- a/cmd/root/test_spec.sh
+++ b/cmd/root/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'root/version'
+Context 'root'
   Example 'Get CLI version'
     When call taikun --version
     The status should equal 0

--- a/cmd/usertoken/test_spec.sh
+++ b/cmd/usertoken/test_spec.sh
@@ -1,4 +1,4 @@
-Context 'usertoken/create'
+Context 'usertoken'
 
     setup() {
         tokenname=$(_rnd_name)

--- a/scripts/tests/rerun_failed_tests.sh
+++ b/scripts/tests/rerun_failed_tests.sh
@@ -22,6 +22,7 @@ fi
 
 failures=0
 
+# Shellspec Context must be named EXACLY as the path leading to the folder containing the spec .sh file.
 for context in $fctx; do
   if [[ ! -d "./cmd/$context" ]]; then
     echo "Error: invalid context $context, please fix context name"


### PR DESCRIPTION
FIX: The tests sometimes had bad context name defined, which caused the rerun failed tests script to fail with: ` Error: invalid context xx/xx/xx, please fix context name`