### PR TITLE
fix: New openstack API returns an etra space

### DIFF
--- a/cmd/project/image/test_spec.sh
+++ b/cmd/project/image/test_spec.sh
@@ -24,7 +24,7 @@ Context 'project/image'
 
   Context
     bind() {
-      img=$(taikun cloud-credential images "$cc" --limit 1 --columns id --no-decorate)
+      img=$(taikun cloud-credential images "$cc" --limit 1 --columns id --no-decorate | xargs)
       taikun project image bind "$id" --image-ids "$img" -q
     }
     BeforeEach 'bind'


### PR DESCRIPTION
Fix: One of the tests was failing because the Openstack API slightly changed. 